### PR TITLE
Add Swahili sw to langs

### DIFF
--- a/langs/sw.json
+++ b/langs/sw.json
@@ -1,0 +1,5 @@
+{
+    "name": "Swahili",
+    "code": "sw",
+    "maintainers": ["orama254","katungi","bmwasonga"]
+}


### PR DESCRIPTION
Greetings @gaearon,

As advised earlier, here is a fresh attempt at translating the new React docs to Swahili. Swahili is a language that is used majorly in the Eastern Africa Region (Kenya, Uganda, Tanzania, Rwanda, Burundi) and widely accepted worldwide. I have previous experience with translating the previous docs to Swahili and I am a native speaker and also proficient in English. I also have experience with open source as both a maintainer and contributor on GitHub.

sw: Nina matarajio mema kwa safari ijayo
en: (Looking forward to the amazing journey ahead)