### PR TITLE
Clarify repository link text

### DIFF
--- a/website/src/App.js
+++ b/website/src/App.js
@@ -47,9 +47,9 @@ function Footer() {
       <p>Don't see your language?</p>
       <p>
         If you are interested in maintaining a translation, follow the
-        instructions at{' '}
+        instructions in the{' '}
         <ExtLink href="https://github.com/reactjs/translations.react.dev">
-          translations.react.dev
+          translations.react.dev repository
         </ExtLink>
         .
       </p>


### PR DESCRIPTION
The text at the bottom of https://translations.react.dev is confusing. It says

> If you are interested in maintaining a translation, follow the instructions at [translations.react.dev](https://github.com/reactjs/translations.react.dev).

The link targets this repository, but it looks like a domain name, as if it actually links to `https://translations.react.dev`.